### PR TITLE
Track status of setts in registry

### DIFF
--- a/subgraphs/badger-dao/config/matic.json
+++ b/subgraphs/badger-dao/config/matic.json
@@ -4,10 +4,6 @@
     "address": "0x22765948A3d5048F3644b81792e4E1aA7ea3da4a",
     "startBlock": 17191330
   },
-  "registryV2": {
-    "address": "0x0000DEAD0000DEAD0000DEAD0000DEAD0000DEAD",
-    "startBlock": 17191330  
-  },
   "setts": [
     {
       "name": "BADGER",

--- a/subgraphs/badger-dao/config/xdai.json
+++ b/subgraphs/badger-dao/config/xdai.json
@@ -4,10 +4,6 @@
     "address": "0x22765948A3d5048F3644b81792e4E1aA7ea3da4a",
     "startBlock": 17199733
   },
-  "registryV2": {
-    "address": "0x0000DEAD0000DEAD0000DEAD0000DEAD0000DEAD",
-    "startBlock": 17199733  
-  },
   "setts": [
     {
       "name": "BADGER",

--- a/subgraphs/badger-dao/schema.graphql
+++ b/subgraphs/badger-dao/schema.graphql
@@ -58,6 +58,8 @@ type Sett implements ERC20 & Vault & VaultBalance @entity {
   grossShareDeposit: BigInt!
   grossWithdraw: BigInt!
   grossShareWithdraw: BigInt!
+  status: String!  # dev, experimental, guarded, open，unregistered
+
 }
 
 type SettSnapshot implements ERC20 & Vault & VaultBalance & Snapshot @entity {

--- a/subgraphs/badger-dao/src/constants.ts
+++ b/subgraphs/badger-dao/src/constants.ts
@@ -34,3 +34,9 @@ export enum SettType {
   v2,
   Affiliate,
 }
+
+export enum SettStatus {
+  experimental,
+  guarded,
+  open,
+}

--- a/subgraphs/badger-dao/src/entities/badger-sett-v2.ts
+++ b/subgraphs/badger-dao/src/entities/badger-sett-v2.ts
@@ -26,6 +26,7 @@ export function loadSettV2(address: Address): Sett {
     sett.netShareDeposit = ZERO;
     sett.grossShareDeposit = ZERO;
     sett.grossShareWithdraw = ZERO;
+    sett.status = "dev";
   }
 
   sett.pricePerFullShare = readValue<BigInt>(contract.try_pricePerShare(), sett.pricePerFullShare);

--- a/subgraphs/badger-dao/src/entities/badger-sett.ts
+++ b/subgraphs/badger-dao/src/entities/badger-sett.ts
@@ -1,7 +1,8 @@
 import { Address, BigInt } from '@graphprotocol/graph-ts';
 import { Sett } from '../../generated/schema';
 import { BadgerSett } from '../../generated/templates/SettVault/BadgerSett';
-import { NO_ADDR, ZERO } from '../constants';
+import { loadSettV2 } from './badger-sett-v2'
+import { NO_ADDR, ZERO, SettStatus } from '../constants';
 import { readValue } from './contracts';
 import { loadToken } from './token';
 
@@ -26,6 +27,7 @@ export function loadSett(address: Address): Sett {
     sett.netShareDeposit = ZERO;
     sett.grossShareDeposit = ZERO;
     sett.grossShareWithdraw = ZERO;
+    sett.status = "dev";
   }
 
   sett.pricePerFullShare = readValue<BigInt>(contract.try_getPricePerFullShare(), sett.pricePerFullShare);
@@ -34,4 +36,36 @@ export function loadSett(address: Address): Sett {
 
   sett.save();
   return sett as Sett;
+}
+
+export function updateSettStatus(address: Address, version: string, status: string): void {
+  let sett = Sett.load(address.toHexString());
+  if (version == "v1") {
+    sett = loadSett(address)
+  } else if (version == "v2") {
+    sett = loadSettV2(address) 
+  }
+  
+  if (sett !== null) {
+    sett.status = status;
+    sett.save();
+  }
+}
+
+export function SettStatusString(status: i32): string {
+  let statusString = "";
+  switch (status) {
+    case SettStatus.experimental:
+      statusString = "experimental";
+      break;
+    case SettStatus.guarded:
+      statusString = "guarded";
+      break;
+    case SettStatus.open:
+      statusString = "open";
+      break;
+    default:
+      "dev";
+  }
+  return statusString as string
 }

--- a/subgraphs/badger-dao/src/handlers/registry-handler.ts
+++ b/subgraphs/badger-dao/src/handlers/registry-handler.ts
@@ -1,13 +1,8 @@
 import { Sett } from '../../generated/schema';
-import { SettVault, SettVaultV2 } from '../../generated/templates';
+import { SettVault } from '../../generated/templates';
 import { NewVault, PromoteVault, RemoveVault } from '../../generated/VaultRegistry/VaultRegistry';
-import {
-  NewVault as NewVaultV2,
-  PromoteVault as PromoteVaultV2,
-  RemoveVault as RemoveVaultV2
-} from '../../generated/VaultRegistryV2/VaultRegistryV2';
-import { loadSett } from '../entities/badger-sett';
-import { loadSettV2 } from '../entities/badger-sett-v2';
+import { loadSett, updateSettStatus } from '../entities/badger-sett';
+
 
 // TODO: consider how to differentiate on author
 export function handleNewVault(event: NewVault): void {
@@ -19,37 +14,10 @@ export function handleNewVault(event: NewVault): void {
   }
 }
 
-// TODO: potentially use for upgrading vault state vs. registering new vaults
-// eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars-experimental
-export function handlePromoteVault(event: PromoteVault): void {}
-
-// TODO: consider vault state (active, deprecated, guarded) via new / promote
-// eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars-experimental
-export function handleRemoveVault(event: RemoveVault): void {}
-
-export function handleNewVaultV2(event: NewVaultV2): void {
-  let vault = event.params.vault;
-  let version = event.params.version;
-
-  if (version == "v1") {
-    let sett = loadSett(vault);
-    if (sett == null) {
-      SettVault.create(vault);
-      loadSett(vault).save();
-    }
-  } else if (version == "v2") {
-    let settV2 = loadSettV2(vault);
-    if (settV2 == null) {
-      SettVaultV2.create(vault);
-      loadSettV2(vault).save();
-    }
-  }
+export function handlePromoteVault(event: PromoteVault): void {
+  updateSettStatus(event.params.vault, "", "open");
 }
 
-// TODO: potentially use for upgrading vault state vs. registering new vaults
-// eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars-experimental
-export function handlePromoteVaultV2(event: PromoteVaultV2): void {}
-
-// TODO: consider vault state (active, deprecated, guarded) via new / promote
-// eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars-experimental
-export function handleRemoveVaultV2(event: RemoveVaultV2): void {}
+export function handleRemoveVault(event: RemoveVault): void {
+  updateSettStatus(event.params.vault, "", "unregistered");
+}

--- a/subgraphs/badger-dao/src/handlers/registry-v2-handler.ts
+++ b/subgraphs/badger-dao/src/handlers/registry-v2-handler.ts
@@ -1,0 +1,37 @@
+import { Sett } from '../../generated/schema';
+import { SettVault, SettVaultV2 } from '../../generated/templates';
+import { NewVault, PromoteVault, DemoteVault, RemoveVault } from '../../generated/VaultRegistryV2/VaultRegistryV2';
+import { loadSett, updateSettStatus, SettStatusString } from '../entities/badger-sett';
+import { loadSettV2 } from '../entities/badger-sett-v2';
+
+
+export function handleNewVault(event: NewVault): void {
+  let vault = event.params.vault;
+  let version = event.params.version;
+
+  let sett = Sett.load(vault.toHexString());
+
+  if (sett == null) {
+    if (version == 'v1') {
+      SettVault.create(vault);
+      loadSett(vault).save();
+    } else if (version == 'v2') {
+      SettVaultV2.create(vault);
+      loadSettV2(vault).save();
+    }
+  }
+}
+
+export function handlePromoteVault(event: PromoteVault): void {  
+  let status = SettStatusString(event.params.status);
+  updateSettStatus(event.params.vault, event.params.version, status);
+}
+
+export function handleDemoteVault(event: DemoteVault): void {
+  let status = SettStatusString(event.params.status);
+  updateSettStatus(event.params.vault, event.params.version, status);
+}
+
+export function handleRemoveVault(event: RemoveVault): void {
+  updateSettStatus(event.params.vault, "", "unregistered");
+}

--- a/subgraphs/badger-dao/subgraph.template.yaml
+++ b/subgraphs/badger-dao/subgraph.template.yaml
@@ -61,12 +61,14 @@ dataSources:
           file: ./abis/BadgerSett.json
       eventHandlers:
         - event: NewVault(address,string,address)
-          handler: handleNewVaultV2
+          handler: handleNewVault
         - event: PromoteVault(address,string,address,uint8)
-          handler: handlePromoteVaultV2
+          handler: handlePromoteVault
+        - event: DemoteVault(address,string,address,uint8)
+          handler: handleDemoteVault
         - event: RemoveVault(address,string,address)
-          handler: handleRemoveVaultV2
-      file: ./src/handlers/registry-handler.ts
+          handler: handleRemoveVault
+      file: ./src/handlers/registry-v2-handler.ts
   {{/registryV2}}
   {{#legacysetts}}
   - kind: ethereum/contract


### PR DESCRIPTION
I removed the placeholders in non-ethereum configs as these are no longer needed.

For registry V1, tracks the following statuses:
1. dev
2. open
3. unregistered

For registry V2, tracks:
1. dev
2. experimental
3. guarded
4. open
5. unregistered